### PR TITLE
Add paths back to destination in redirect rules

### DIFF
--- a/docker-assets/manageiq.conf
+++ b/docker-assets/manageiq.conf
@@ -30,8 +30,8 @@ RewriteRule ^.*$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
   ProxyPass /cws/ http://${MANAGEIQ_SERVICE_NAME}:9002/cws/
 
   ### API redirects
-  ProxyPass /api https://${MANAGEIQ_SERVICE_NAME}
-  ProxyPassReverse /api https://${MANAGEIQ_SERVICE_NAME}
+  ProxyPass /api https://${MANAGEIQ_SERVICE_NAME}/api
+  ProxyPassReverse /api https://${MANAGEIQ_SERVICE_NAME}/api
 
   ### UI redirects
   RewriteCond %{REQUEST_URI} !^/ws
@@ -43,8 +43,8 @@ RewriteRule ^.*$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
   ProxyPassReverse / https://${MANAGEIQ_SERVICE_NAME}/
 
   ### WebSocket redirects
-  ProxyPass /ws ws://${MANAGEIQ_SERVICE_NAME}
-  ProxyPassReverse /ws ws://${MANAGEIQ_SERVICE_NAME}
+  ProxyPass /ws ws://${MANAGEIQ_SERVICE_NAME}/ws
+  ProxyPassReverse /ws ws://${MANAGEIQ_SERVICE_NAME}/ws
 
   ProxyPreserveHost on
   RequestHeader set X_FORWARDED_PROTO 'https'


### PR DESCRIPTION
This was broken in 45c396fda70858b80f3d7cd4f5ce8ea942838eae and prevented login as /api was not routable.