### PR TITLE
Drop all SSL logic from the httpd container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,20 @@ LABEL name="manageiq-apache" \
       description="ManageIQ is a management and automation platform for virtual, private, and hybrid cloud infrastructures." \
       io.k8s.display-name="ManageIQ Apache" \
       io.k8s.description="ManageIQ Apache is the front-end for the ManageIQ Application." \
-      io.openshift.expose-services="443:https" \
+      io.openshift.expose-services="80:http" \
       io.openshift.tags="ManageIQ-Apache,apache"
 
 ## Install EPEL repo, yum necessary packages for the build without docs, clean all caches
 RUN yum -y install centos-release-scl-rh && \
-    yum -y install --setopt=tsflags=nodocs mod_ssl && \
     yum clean all
 
 ## Remove any existing configurations
 RUN rm -f /etc/httpd/conf.d/*
 
 COPY docker-assets/entrypoint /usr/bin
-COPY docker-assets/generate_server_cert.sh /usr/bin
 COPY docker-assets/manageiq.conf /etc/httpd/conf.d/
 
-RUN chmod +x /usr/bin/generate_server_cert.sh
-
-EXPOSE 80 443
+EXPOSE 80
 
 ENTRYPOINT [ "entrypoint" ]
 CMD ["/run-httpd.sh"]

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-/usr/bin/generate_server_cert.sh
-
 exec "$@"

--- a/docker-assets/generate_server_cert.sh
+++ b/docker-assets/generate_server_cert.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e -o pipefail
-
-mkdir -p /etc/httpd/certs/
-CERT="/etc/httpd/certs/server.cer"
-KEY="$CERT.key"
-if [ ! -f "$CERT" -a ! -f "$KEY" ]; then
-  (umask 077 ; openssl req -x509 -newkey rsa -days 1095 -keyout $KEY -out $CERT -subj "/CN=server" -nodes -batch)
-fi

--- a/docker-assets/manageiq.conf
+++ b/docker-assets/manageiq.conf
@@ -4,85 +4,10 @@ Timeout 120
 # Disable this section if using HTTP only
 RewriteEngine On
 Options SymLinksIfOwnerMatch
-RewriteCond %{SERVER_PORT} !^443$
-RewriteRule ^.*$ https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
 
-## ManageIQ SSL Virtual Host Context
-<VirtualHost *:443>
+<VirtualHost *:80>
   KeepAlive on
-
-  # To forward to the internal httpd servers in the app and ignore their self-signed certificates.
-  SSLProxyEngine On
-  SSLProxyVerify none
-  SSLProxyCheckPeerCN off
-  SSLProxyCheckPeerName off
-  SSLProxyCheckPeerExpire off
-
-  # The following redirects files must be included to handle most specific to least specific URLs.
-
-  ### Cockpit redirects
   ProxyPreserveHost on
-  RequestHeader unset X-Forwarded-Proto
-  RequestHeader set X-Forwarded-Proto 'https' env=HTTPS
-  <LocationMatch "^/cws/cockpi(t[^/]+|t)?/socket$">
-    ProxyPassMatch "ws://${MANAGEIQ_SERVICE_NAME}:9002/cws/cockpi$1/socket"
-  </LocationMatch>
-  ProxyPass /cws/ http://${MANAGEIQ_SERVICE_NAME}:9002/cws/
-
-  ### API redirects
-  ProxyPass /api https://${MANAGEIQ_SERVICE_NAME}/api
-  ProxyPassReverse /api https://${MANAGEIQ_SERVICE_NAME}/api
-
-  ### UI redirects
-  RewriteCond %{REQUEST_URI} !^/ws
-  RewriteCond %{REQUEST_URI} !^/proxy_pages
-  RewriteCond %{REQUEST_URI} !^/saml2
-  RewriteCond %{REQUEST_URI} !^/api
-  RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_FILENAME} !-f
-  RewriteRule ^/ https://${MANAGEIQ_SERVICE_NAME}%{REQUEST_URI} [P,QSA,L]
-  ProxyPassReverse / https://${MANAGEIQ_SERVICE_NAME}/
-
-  ### WebSocket redirects
-  ProxyPass /ws ws://${MANAGEIQ_SERVICE_NAME}/ws
-  ProxyPassReverse /ws ws://${MANAGEIQ_SERVICE_NAME}/ws
-
-  ProxyPreserveHost on
-  RequestHeader set X_FORWARDED_PROTO 'https'
-
-  ErrorLog /var/log/httpd/ssl_error.log
-  TransferLog /var/log/httpd/ssl_access.log
-  LogLevel warn
-
-  SSLEngine on
-  SSLProtocol all -SSLv2 -SSLv3
-  SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:!LOW
-  SSLCertificateFile /etc/httpd/certs/server.cer
-  SSLCertificateKeyFile /etc/httpd/certs/server.cer.key
-
-  SetEnvIf User-Agent ".*MSIE.*" \
-         nokeepalive ssl-unclean-shutdown \
-         downgrade-1.0 force-response-1.0
-
-  CustomLog /var/log/httpd/ssl_request.log \
-          "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
-
+  ProxyPass / http://manageiq/
+  ProxyPassReverse / http://manageiq/
 </VirtualHost>
-
-## ManageIQ SSL Global Context
-
-Listen 443
-
-AddType application/x-x509-ca-cert .crt
-AddType application/x-pkcs7-crl    .crl
-
-SSLPassPhraseDialog  builtin
-
-SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
-SSLSessionCacheTimeout  300
-
-Mutex default ssl-cache
-
-SSLRandomSeed startup file:/dev/urandom  256
-SSLRandomSeed connect builtin
-
-SSLCryptoDevice builtin


### PR DESCRIPTION
This allows us to move all SSL logic to the route and simplifies the config
Also drop the env variable for the manageiq service, it can be static.

Must be merged at the same time as https://github.com/ManageIQ/manageiq-pods/pull/197
cc @abellotti 