### PR TITLE
Added support for an httpd authentication configuration map

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM centos/httpd:latest
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 
-## Systemd
 ENV container oci
 
 ## Atomic/OpenShift Labels
@@ -61,11 +60,19 @@ RUN (cd /lib/systemd/system/sysinit.target.wants && for i in *; do [ $i == syste
 ## Remove any existing configurations
 RUN rm -f /etc/httpd/conf.d/*
 
+## Create the mount point for the authentication configuration files
+RUN mkdir /etc/httpd/auth-conf.d
+
+COPY docker-assets/entrypoint               /usr/bin
+COPY docker-assets/initialize-httpd-auth.sh /usr/bin
+
+COPY docker-assets/initialize-httpd-auth.service /usr/lib/systemd/system/initialize-httpd-auth.service
+
 EXPOSE 80
 
 WORKDIR /etc/httpd
 
-RUN systemctl enable httpd
+RUN systemctl enable initialize-httpd-auth httpd
 
 VOLUME /sys/fs/cgroup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos/httpd:latest
 MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 
+## Systemd
 ENV container oci
 
 ## Atomic/OpenShift Labels
@@ -67,6 +68,10 @@ COPY docker-assets/entrypoint               /usr/bin
 COPY docker-assets/initialize-httpd-auth.sh /usr/bin
 
 COPY docker-assets/initialize-httpd-auth.service /usr/lib/systemd/system/initialize-httpd-auth.service
+
+## Make sure httpd has the environment variables needed for external auth
+RUN  mkdir -p /etc/systemd/system/httpd.service.d
+COPY docker-assets/httpd-environment.conf /etc/systemd/system/httpd.service.d/environment.conf
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ RUN rm -f /etc/httpd/conf.d/*
 ## Create the mount point for the authentication configuration files
 RUN mkdir /etc/httpd/auth-conf.d
 
-COPY docker-assets/entrypoint               /usr/bin
-COPY docker-assets/initialize-httpd-auth.sh /usr/bin
+COPY docker-assets/save-container-environment /usr/bin
+COPY docker-assets/initialize-httpd-auth.sh   /usr/bin
 
 COPY docker-assets/initialize-httpd-auth.service /usr/lib/systemd/system/initialize-httpd-auth.service
 

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-/usr/bin/initialize-httpd-auth.sh
+# /usr/bin/entrypoint is now run by lifecycle postStart.
 
-exec "$@"
+# the environment will include PATH and such, and for
+# for systemd services in container-httpd we use and only
+# want the HTTPD_ ones defined.
+#
+env | grep "^HTTPD_" | sort > /etc/container-environment

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+/usr/bin/initialize-httpd-auth.sh
+
+exec "$@"

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# /usr/bin/entrypoint is now run by lifecycle postStart.
-
-# the environment will include PATH and such, and for
-# for systemd services in container-httpd we use and only
-# want the HTTPD_ ones defined.
-#
-env | grep "^HTTPD_" | sort > /etc/container-environment

--- a/docker-assets/httpd-environment.conf
+++ b/docker-assets/httpd-environment.conf
@@ -1,0 +1,3 @@
+[Service]
+ConditionPathExists=/etc/container-environment
+EnvironmentFile=/etc/container-environment

--- a/docker-assets/initialize-httpd-auth.service
+++ b/docker-assets/initialize-httpd-auth.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Initializes Httpd External Authentication
+Before=network-pre.target
+Wants=network-pre.target
+[Service]
+Type=oneshot
+ConditionPathExists=/etc/container-environment
+EnvironmentFile=/etc/container-environment
+ExecStart=/usr/bin/initialize-httpd-auth.sh
+[Install]
+WantedBy=multi-user.target

--- a/docker-assets/initialize-httpd-auth.sh
+++ b/docker-assets/initialize-httpd-auth.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+HTTPD_AUTH_CONFIG_DIR=/etc/httpd/auth-conf.d
+AUTH_CONFIG_FILE="${HTTPD_AUTH_CONFIG_DIR}/auth-configuration.conf"
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+
+function trim_whitespace {
+  sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+function auth_type {
+  if [ -f ${AUTH_CONFIG_FILE} ]
+  then
+    CONFIG_AUTH_TYPE=$(grep '^type[[:space:]]*=.*$' ${AUTH_CONFIG_FILE} | cut -f2 -d= | trim_whitespace)
+  fi
+  echo ${CONFIG_AUTH_TYPE:-internal}
+}
+
+function auth_files {
+  if [ -f ${AUTH_CONFIG_FILE} ]
+  then
+    grep '^file[[:space:]]*=.*$' ${AUTH_CONFIG_FILE} | cut -f2 -d= | trim_whitespace
+  fi
+}
+
+AUTH_TYPE=$(auth_type)
+echo "Authentication Type: ${AUTH_TYPE}"
+
+if [ "${AUTH_TYPE}" == "internal" ]
+then
+  echo "No External Authentication Defined."
+  exit 0
+fi
+
+echo "Initializing $AUTH_TYPE External Authentication"
+
+echo "Copying Authentication Files:"
+auth_files | \
+( SSSD_CONF="no"
+  while read source_file target_file file_permission
+  do
+    [[ ${target_file} == ${SSSD_CONF_FILE} ]] && SSSD_CONF="yes"
+    BINARY=""; [[ ${source_file} =~ \.base64$ ]] && BINARY="BINARY"
+    printf "Copying: %s => %s (%s) %s\n" ${source_file} ${target_file} ${file_permission:-unspecified} $BINARY
+    TARGET_DIR="`dirname ${target_file}`"
+    [[ ! -d "${TARGET_DIR}" ]] && /usr/bin/mkdir -p "${TARGET_DIR}"
+    if [ -n "${BINARY}" ]
+    then
+      cat ${HTTPD_AUTH_CONFIG_DIR}/${source_file} | /usr/bin/base64 -d > ${target_file}
+    else
+      cp ${HTTPD_AUTH_CONFIG_DIR}/${source_file} ${target_file}
+    fi
+    if [ $? -ne 0 ]
+    then
+      echo "Failed to copy file ${target_file}" >&2
+      exit 1
+    fi
+    PERMS=(`echo $file_permission | awk -F: '{print $1, $2, $3}'`)
+    [[ -n "${PERMS[0]}" ]] && /usr/bin/chmod ${PERMS[0]} ${target_file}
+    [[ -n "${PERMS[1]}" ]] && /usr/bin/chgrp ${PERMS[1]} ${target_file}
+    [[ -n "${PERMS[2]}" ]] && /usr/bin/chown ${PERMS[2]} ${target_file}
+  done
+
+  echo ""
+  if [ $SSSD_CONF == "yes" ]
+  then
+    echo "SSSD File ${SSSD_CONF_FILE} copied, Enabling SSSD ..."
+    systemctl enable sssd
+  fi
+)
+echo "Finished copying Authentication Files."
+
+exit 0

--- a/docker-assets/initialize-httpd-auth.sh
+++ b/docker-assets/initialize-httpd-auth.sh
@@ -8,14 +8,6 @@ function trim_whitespace {
   sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
 }
 
-function auth_type {
-  if [ -f ${AUTH_CONFIG_FILE} ]
-  then
-    CONFIG_AUTH_TYPE=$(grep '^type[[:space:]]*=.*$' ${AUTH_CONFIG_FILE} | cut -f2 -d= | trim_whitespace)
-  fi
-  echo ${CONFIG_AUTH_TYPE:-internal}
-}
-
 function auth_files {
   if [ -f ${AUTH_CONFIG_FILE} ]
   then
@@ -23,7 +15,7 @@ function auth_files {
   fi
 }
 
-AUTH_TYPE=$(auth_type)
+AUTH_TYPE=${HTTPD_AUTH_TYPE:-internal}
 echo "Authentication Type: ${AUTH_TYPE}"
 
 if [ "${AUTH_TYPE}" == "internal" ]

--- a/docker-assets/save-container-environment
+++ b/docker-assets/save-container-environment
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This is executed by the lifecycle postStart so the environment
+# will include PATH and such. systemd services in container-httpd
+# only use the HTTPD_ ones defined.
+#
+env | grep "^HTTPD_" | sort > /etc/container-environment


### PR DESCRIPTION
Added support for an authentication config file directory is mounted from a configmap.

- Authentication Configuration Map mounted in:
    /etc/httpd/auth-conf.d/

- Config file driving the initialization is:
    /etc/httpd/auth-conf.d/auth-configuration.conf

- New script to overlay the external authentication files is:
    /usr/bin/initialize-httpd-auth.sh and invoked from the entrypoint.

Needs to be merged with: https://github.com/ManageIQ/manageiq-pods/pull/201
