### PR TITLE
Fixed httpd startup issue

### DIFF
--- a/docker-assets/httpd-environment.conf
+++ b/docker-assets/httpd-environment.conf
@@ -1,3 +1,5 @@
-[Service]
+[Unit]
+After=initialize-httpd-auth.service
 ConditionPathExists=/etc/container-environment
+[Service]
 EnvironmentFile=/etc/container-environment


### PR DESCRIPTION
- ConditionPathExists should have been defined in the Unit section
- Timing issue with initialize-httpd-auth, we needed the After directive as that was sometimes failing SAML startups.