### PR TITLE
httpd service waits for /etc/container-env file to be created

### DIFF
--- a/docker-assets/initialize-httpd-auth.service
+++ b/docker-assets/initialize-httpd-auth.service
@@ -2,10 +2,9 @@
 Description=Initializes Httpd External Authentication
 Before=network-pre.target
 Wants=network-pre.target
-ConditionPathExists=/etc/container-environment
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/container-environment
+ExecStartPre=/bin/bash -c "until [ -f /etc/container-environment ]; do sleep 1; done"
 ExecStart=/usr/bin/initialize-httpd-auth.sh
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
this fixes #18 

modifies the httpd service to wait for a trivial service `wait-for-container-env` which sleeps until `/etc/container-environment` has been created. 

this workaround is needed because systemd doesn't currently support restarting services on dependency failures (https://github.com/systemd/systemd/issues/1312)