### PR TITLE
initialize-httpd-auth.service was no longer honoring ext-auth environment.

### DIFF
--- a/docker-assets/initialize-httpd-auth.service
+++ b/docker-assets/initialize-httpd-auth.service
@@ -6,5 +6,6 @@ Wants=network-pre.target
 Type=oneshot
 ExecStartPre=/bin/bash -c "until [ -f /etc/container-environment ]; do sleep 1; done"
 ExecStart=/usr/bin/initialize-httpd-auth.sh
+EnvironmentFile=/etc/container-environment
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We somehow lost the EnvironmentFile=/etc/container-environment entry
from the initialize-httpd-auth.service.

Without that we were no longer seeing the ext-auth configurations
coming in from the httpd-auth-config map.