### PR TITLE
Remove bogus real-md package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ RUN yum -y install centos-release-scl-rh && \
     # Active Directory External Authentication Packages \
     yum -y install --setopt=tsflags=nodocs adcli                        \
                                            realmd                       \
-                                           real-md                      \
                                            oddjob                       \
                                            oddjob-mkhomedir             \
                                            samba-common                 \


### PR DESCRIPTION
- was never noticed during the docker build
- "No package real-md available"

Thanks to Satoe for finding this.