### PR TITLE
Fixes an issue where auth sometimes fails to initialize for downstream images.

### DIFF
--- a/container-assets/dbus-api.service
+++ b/container-assets/dbus-api.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Starts the Httpd DBus API Service
-After=dbus.service
-ConditionPathExists=/etc/container-environment
+After=httpd.service
 [Service]
 EnvironmentFile=/etc/container-environment
+ExecStartPre=/bin/bash -c "until [ -s /etc/container-environment ]; do sleep 1; done"
 ExecStart=/bin/bash -c "cd ${HTTPD_DBUS_API_SERVICE_DIRECTORY} && bin/dbus_api_service"
 [Install]
 WantedBy=multi-user.target

--- a/container-assets/dbus-api.service
+++ b/container-assets/dbus-api.service
@@ -2,7 +2,7 @@
 Description=Starts the Httpd DBus API Service
 After=httpd.service
 [Service]
-EnvironmentFile=/etc/container-environment
+EnvironmentFile=-/etc/container-environment
 ExecStartPre=/bin/bash -c "until [ -s /etc/container-environment ]; do sleep 1; done"
 ExecStart=/bin/bash -c "cd ${HTTPD_DBUS_API_SERVICE_DIRECTORY} && bin/dbus_api_service"
 [Install]

--- a/container-assets/dbus-api.service
+++ b/container-assets/dbus-api.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Starts the Httpd DBus API Service
-After=httpd.service
+After=dbus.service
 [Service]
 EnvironmentFile=-/etc/container-environment
 ExecStartPre=/bin/bash -c "until [ -s /etc/container-environment ]; do sleep 1; done"

--- a/container-assets/initialize-httpd-auth.service
+++ b/container-assets/initialize-httpd-auth.service
@@ -4,7 +4,7 @@ Before=network-pre.target
 Wants=network-pre.target
 [Service]
 Type=oneshot
-ExecStartPre=/bin/bash -c "until [ -f /etc/container-environment ]; do sleep 1; done"
+ExecStartPre=/bin/bash -c "until [ -s /etc/container-environment ]; do sleep 1; done"
 ExecStart=/usr/bin/initialize-httpd-auth.sh
 EnvironmentFile=/etc/container-environment
 [Install]

--- a/container-assets/initialize-httpd-auth.service
+++ b/container-assets/initialize-httpd-auth.service
@@ -4,8 +4,8 @@ Before=network-pre.target
 Wants=network-pre.target
 [Service]
 Type=oneshot
+EnvironmentFile=-/etc/container-environment
 ExecStartPre=/bin/bash -c "until [ -s /etc/container-environment ]; do sleep 1; done"
 ExecStart=/usr/bin/initialize-httpd-auth.sh
-EnvironmentFile=/etc/container-environment
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes an issue where auth sometimes fails to initialize for downstream images.
- Updated unit initialization code for initialize-httpd-auth and dbus-api services to wait for properly sized container environment file.
- waiting to start dbus-api service after httpd

https://bugzilla.redhat.com/show_bug.cgi?id=1540678

https://bugzilla.redhat.com/show_bug.cgi?id=1566488
