### PR TITLE
Move from apache module mod_auth_kerb to mod_auth_gssapi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN yum -y install centos-release-scl-rh && \
                                            && \
     # Apache External Authentication Module Packages \
     yum -y install --setopt=tsflags=nodocs mod_auth_kerb                \
+                                           mod_auth_gssapi              \
                                            mod_authnz_pam               \
                                            mod_intercept_form_submit    \
                                            mod_lookup_identity          \


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/160297262

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650583

This PR is one of two that will implement moving external authentication support from
the Apache module mod_auth_kerb to mod_auth_gssapi for the Openshift/podified build

