### PR TITLE
Added labels to image build to address red hat certification failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM registry.access.redhat.com/ubi8/ubi:8.3
 
 ARG ARCH=x86_64
 
+LABEL name="Httpd" \
+      summary="Httpd Image" \
+      vendor="ManageIQ" \
+      description="Apache HTTP Server"
+
 RUN dnf -y --disableplugin=subscription-manager install \
       http://mirror.centos.org/centos/8.3.2011/BaseOS/${ARCH}/os/Packages/centos-linux-repos-8-2.el8.noarch.rpm \
       http://mirror.centos.org/centos/8.3.2011/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \


### PR DESCRIPTION
Addresses these failures -
![image](https://user-images.githubusercontent.com/76593/109552517-de209c80-7a9f-11eb-97c4-b2c3691995aa.png)
