### PR TITLE
Install all httpd dependencies before enabling CentOS repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,14 @@ LABEL name="Httpd" \
       vendor="ManageIQ" \
       description="Apache HTTP Server"
 
-RUN if [ $(uname -m) != "s390x" ] ; then \
+RUN dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
+      httpd \
+      mod_ssl \
+      procps-ng && \
+    if [ $(uname -m) != "s390x" ] ; then \
       dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
         http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \
-      dnf config-manager --setopt=appstream*.exclude=*httpd*,mod_ssl --save && \
       dnf -y --disableplugin=subscription-manager module enable mod_auth_openidc && \
       dnf -y --disableplugin=subscription-manager install mod_auth_openidc; \
     else \
@@ -30,10 +33,6 @@ RUN if [ $(uname -m) != "s390x" ] ; then \
         /opt/app-root/src/bin-rpm-dir/mod_auth_openidc-2.3*.s390x.rpm && \
       rm -rf /opt/app-root/src/bin-rpm-dir; \
     fi && \
-    dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
-      httpd \
-      mod_ssl \
-      procps-ng && \
     dnf clean all && \
     rm -rf /var/cache/dnf && \
     chmod -R g+w /etc/pki/ca-trust && \


### PR DESCRIPTION
This ensures that the dependencies all come from UBI rather than listing each one in an exception list
We were getting mod_http2 from CentOS Appstream and it caused the error:
`httpd: Syntax error on line 58 of /etc/httpd/conf/httpd.conf: Syntax error on line 1 of /etc/httpd/conf.modules.d/10-h2.conf: Cannot load modules/mod_http2.so into server: /etc/httpd/modules/mod_http2.so: undefined symbol: ap_post_read_request`

List of indirect dependencies:
```
Dependencies resolved.
================================================================================================
 Package              Arch    Version                                     Repository        Size
================================================================================================
Installing:
 httpd                x86_64  2.4.37-43.module+el8.5.0+14530+6f259f31.3   ubi-8-appstream  1.4 M
 mod_ssl              x86_64  1:2.4.37-43.module+el8.5.0+14530+6f259f31.3 ubi-8-appstream  137 k
 procps-ng            x86_64  3.3.15-6.el8                                ubi-8-baseos     329 k
Installing dependencies:
 apr                  x86_64  1.6.3-12.el8                                ubi-8-appstream  130 k
 apr-util             x86_64  1.6.1-6.el8                                 ubi-8-appstream  105 k
 httpd-filesystem     noarch  2.4.37-43.module+el8.5.0+14530+6f259f31.3   ubi-8-appstream   40 k
 httpd-tools          x86_64  2.4.37-43.module+el8.5.0+14530+6f259f31.3   ubi-8-appstream  107 k
 libpath_utils        x86_64  0.2.1-39.el8                                ubi-8-baseos      34 k
 libtalloc            x86_64  2.3.2-1.el8                                 ubi-8-baseos      49 k
 mailcap              noarch  2.1.48-3.el8                                ubi-8-baseos      39 k
 mod_http2            x86_64  1.15.7-3.module+el8.4.0+8625+d397f3da       ubi-8-appstream  154 k
 redhat-logos-httpd   noarch  84.5-1.el8                                  ubi-8-baseos      29 k
 sscg                 x86_64  2.3.3-14.el8                                ubi-8-appstream   49 k
Installing weak dependencies:
 apr-util-bdb         x86_64  1.6.1-6.el8                                 ubi-8-appstream   25 k
 apr-util-openssl     x86_64  1.6.1-6.el8                                 ubi-8-appstream   27 k
Enabling module streams:
 httpd                        2.4

Transaction Summary
================================================================================================
Install  15 Packages
```