### PR TITLE
Lock down to ubi8.8-1032

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN cd /tmp && \
     if [[ "$(cat .git/HEAD)" == "ref:"* ]]; then sha=$(cat .git/$sha); fi && \
     echo "$(date +"%Y%m%d%H%M%S")-$sha" > /tmp/BUILD
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
 
 LABEL name="Httpd" \
       summary="Httpd Image" \


### PR DESCRIPTION
/etc/yum.repos.d/ubi.repo is missing from
registry.redhat.io/ubi8:8.8-1032.1692772289(latest) for PPC64le

latest minimal, micro and s2i-core are fine

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=2233877

Fixes build error:
```
warning: rpmdb: BDB2053 Freeing read locks for locker 0x1: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x3: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x4: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x5: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x6: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x7: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x8: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x9: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0xa: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0xb: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0xc: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0xd: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0xe: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0xf: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x10: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x11: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x12: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x13: 2222/140735876952432 
warning: rpmdb: BDB2053 Freeing read locks for locker 0x14: 2222/140735876952432 
Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d".
```