### PR TITLE
Revert "Lock down to ubi8.8-1032"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN cd /tmp && \
     if [[ "$(cat .git/HEAD)" == "ref:"* ]]; then sha=$(cat .git/$sha); fi && \
     echo "$(date +"%Y%m%d%H%M%S")-$sha" > /tmp/BUILD
 
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
+FROM registry.access.redhat.com/ubi8/ubi
 
 LABEL name="Httpd" \
       summary="Httpd Image" \


### PR DESCRIPTION
This reverts commit 62f6650074cfb901d69e9831299fc0028e7c58ed.

A new UBI8 image has been released. The yum repos are available on ppc64le now.