### PR TITLE
[2-EL8] CentOS Stream 8 is EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN ARCH=$(uname -m) && \
       procps-ng && \
     if [ $(uname -m) != "s390x" ] ; then \
       dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
-        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-        http://mirror.centos.org/centos/8-stream/BaseOS/${ARCH}/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm && \
+        https://rpm.manageiq.org/builds/centos/centos-stream-repos-8-6.1.el8.noarch.rpm \
+        https://rpm.manageiq.org/builds/centos/centos-gpg-keys-8-6.1.el8.noarch.rpm && \
       dnf -y --disableplugin=subscription-manager module enable mod_auth_openidc && \
       dnf -y --disableplugin=subscription-manager install mod_auth_openidc; \
     else \


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq-rpm_build/pull/467

Unfortunately the repos RPM in the vault still points to mirrors.centos.org which is no longer serving Stream 8. I patched the RPMs and posted them on rpm.manageiq.org with a change to point all repos to the vault.