### PR TITLE
[2-EL9] Don't install weak dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ LABEL name="Httpd" \
       description="Apache HTTP Server"
 
 RUN ARCH=$(uname -m) && \
+    dnf config-manager --setopt=tsflags=nodocs --setopt=install_weak_deps=False --save && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs update && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       httpd \


### PR DESCRIPTION
With this change, it won't install mod_http2 which resolves CVE-2018-17189