### PR TITLE
[WIP] [2-EL9] Switch to running as the apache user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,11 @@ RUN ARCH=$(uname -m) && \
       mod_auth_openidc && \
     dnf clean all && \
     rm -rf /var/cache/dnf && \
-    chmod -R g+w /etc/pki/ca-trust && \
-    chmod -R g+w /usr/share/pki/ca-trust-legacy
+    chmod -R a+rw /etc/pki/ca-trust && \
+    chmod -R a+rw /usr/share/pki/ca-trust-legacy
 
 # Fix permissions so that httpd can run in the restricted scc
-RUN chgrp root /var/run/httpd && chmod g+rwx /var/run/httpd  && \
-    chgrp root /var/log/httpd && chmod g+rwx /var/log/httpd
+RUN chmod g+rwx /var/run/httpd
 
 # Remove any existing configs in conf.d and don't try to bind to port 80
 RUN rm -f /etc/httpd/conf.d/* && \
@@ -43,5 +42,7 @@ RUN mkdir -p /opt/manageiq/manifest
 COPY --from=manifest /tmp/BUILD /opt/manageiq/manifest
 
 EXPOSE 8080
+
+USER 48
 
 CMD ["/cmd"]


### PR DESCRIPTION
- apache user needs permissions to run `update-ca-trust`
- ` /var/run/httpd` is owned by root:apache, but the group has no permissions

This fixes `Error: container has runAsNonRoot and image will run as root` on this container.

Todo:
- [ ] Test on OpenShift cluster