### PR TITLE
[2-EL9] Fix update-ca-trust error - p11-kit: couldn't make directory writable

### DIFF
--- a/container-assets/cmd
+++ b/container-assets/cmd
@@ -1,3 +1,9 @@
 #!/bin/bash
-update-ca-trust
+
+# Extract to a tmpdir to avoid: p11-kit: couldn't make directory writable: /etc/pki/ca-trust/extracted/pem/directory-hash: Unknown error 1
+mkdir /tmp/extracted
+update-ca-trust extract -o /tmp/extracted/
+rm -rf /etc/pki/ca-trust/extracted/*
+mv /tmp/extracted/* /etc/pki/ca-trust/extracted/
+
 exec /usr/sbin/httpd -D FOREGROUND -E /dev/stderr


### PR DESCRIPTION
TODO:
- [x] Test in an env with SSL between pods
- [x] Double check ownership and permissions on the /etc/pki directories after the mv

Helpful discussion in https://bugzilla.redhat.com/show_bug.cgi?id=2241240

CP4AIOPS-11300

New startup logs:
```
$ oc logs -f httpd-84c96f9985-bj6tp
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.254.20.246. Set the 'ServerName' directive globally to suppress this message
[Wed Feb 26 23:20:51.265974 2025] [ssl:warn] [pid 1:tid 1] AH01909: %{REQUEST_HOST}:443:0 server certificate does NOT include an ID which matches the server name
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 10.254.20.246. Set the 'ServerName' directive globally to suppress this message
[Wed Feb 26 23:20:51.284887 2025] [ssl:warn] [pid 1:tid 1] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]
[Wed Feb 26 23:20:51.285541 2025] [ssl:warn] [pid 1:tid 1] AH01909: %{REQUEST_HOST}:443:0 server certificate does NOT include an ID which matches the server name
[Wed Feb 26 23:20:51.286239 2025] [lbmethod_heartbeat:notice] [pid 1:tid 1] AH02282: No slotmem from mod_heartmonitor
[Wed Feb 26 23:20:51.293035 2025] [mpm_event:notice] [pid 1:tid 1] AH00489: Apache/2.4.62 (Red Hat Enterprise Linux) OpenSSL/3.2.2 configured -- resuming normal operations
[Wed Feb 26 23:20:51.293056 2025] [core:notice] [pid 1:tid 1] AH00094: Command line: '/usr/sbin/httpd -D FOREGROUND -E /dev/stderr'
```
